### PR TITLE
manage update tracking correctly in mounted volume

### DIFF
--- a/addFunctions.py
+++ b/addFunctions.py
@@ -103,7 +103,7 @@ def get_mirror_dir(args):
             minDate = datetime.strptime(args.minDate, '%Y-%m-%d')
             maxDate = datetime.strptime(args.maxDate, '%Y-%m-%d')
         else:
-            minDate = tf.get_last_updated(filename='lastUpdated.txt')
+            minDate = tf.get_last_updated(filename='/usr/src/argo-database/logs/lastUpdated.txt')
             maxDate = datetime.today()
         if (args.subset=='dateRange'):
             df = tf.get_df_from_dates(minDate, maxDate)

--- a/add_profiles.py
+++ b/add_profiles.py
@@ -53,7 +53,7 @@ if __name__ == '__main__':
 
     if (args.subset == 'tmp') or (args.subset == 'dateRange'):
         logging.warning('cleaning up tmp')
-        #af.tmp_clean_up()
+        af.tmp_clean_up()
 
     for file in glob.glob(r'*.txt'):
         shutil.copy(file, 'logs/') 

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -18,7 +18,7 @@ spec:
                 claimName: datacron-logs
           containers:
             - name: argo-update
-              image: argovis/datacron:0.2.0
+              image: argovis/datacron:0.3.0
               imagePullPolicy: Always
               resources:
                 requests:

--- a/tmpFunctions.py
+++ b/tmpFunctions.py
@@ -121,7 +121,7 @@ def create_dir_of_files(df, GDAC, ftpPath, tmpDir):
     os.system(rsyncCommand)
     os.remove(tmpFileName)
             
-def get_last_updated(filename='lastUpdated.txt'):
+def get_last_updated(filename='/usr/src/argo-database/logs/lastUpdated.txt'):
     if not os.path.exists(filename):
         print('{} does not exist. assuming yesterday'.format(filename))
         return datetime.today() - timedelta(days=1)
@@ -131,7 +131,7 @@ def get_last_updated(filename='lastUpdated.txt'):
     date = datetime.strptime(dateStr, '%Y-%m-%d')
     return date
     
-def write_last_updated(date, filename='lastUpdated.txt'):
+def write_last_updated(date, filename='/usr/src/argo-database/logs/lastUpdated.txt'):
     with open(filename, 'w') as f:
         f.write(date)    
 


### PR DESCRIPTION
Or else the update job only looks back 24h, rather than all the way to the previous midnight, resulting in a slightly different update.