### PR TITLE
updates for openshift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ FROM argovis/datacron:base-211117 as head
 COPY ./*.py .
 COPY ./*.nc .
 RUN mkdir logs
-RUN chown -R 1000830000:1000830000 /usr/src/argo-database
-USER 1000830000:1000830000
+RUN chown -R 1000660000:1000660000 /usr/src/argo-database
+USER 1000660000:1000660000
 CMD python add_profiles.py --dbName argo --subset tmp --logName /usr/src/argo-database/logs/tmp.log --npes 1

--- a/cronjob.yaml
+++ b/cronjob.yaml
@@ -3,14 +3,14 @@ kind: CronJob
 metadata:
   name: argo-update
 spec:
-  schedule: "0 8 * * *"
+  schedule: "0 * * * *"
   jobTemplate:
     spec:
       template:
         metadata:
           name: argo-update
           labels:
-            app: api # pretend to be the api to get through the networkPolicy
+            tier: api
         spec:
           volumes:
             - name: logs
@@ -18,7 +18,7 @@ spec:
                 claimName: datacron-logs
           containers:
             - name: argo-update
-              image: argovis/datacron:0.3.0
+              image: argovis/datacron:0.4.0
               imagePullPolicy: Always
               resources:
                 requests:
@@ -32,5 +32,5 @@ spec:
                   name: logs
           restartPolicy: OnFailure
           securityContext:
-            runAsUser: 1000830000
-            runAsGroup: 1000830000
+            runAsUser: 1000660000
+            runAsGroup: 1000660000


### PR DESCRIPTION
 - openshift instance is configured to allow a different UID:GID range than OKD was
 - run cronjob hourly instead of daily
 - track labeling changes from https://github.com/argovis/argovis_deployment/pull/16